### PR TITLE
Cache HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 - Add `rust_version` for checking the currently active version of rust.
+- Cache HTTP requests. Requests will be cached for 1 hour by default. This can
+  be customized by setting `TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS`.
 
 # 0.1.0 (05. September, 2021)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ __internal_http = [
     "serde_json",
     "tokio",
     "webpki-roots",
+    "chrono/serde",
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ More information about this crate can be found in the [crate documentation][docs
 ## License
 
 This project is licensed under the [MIT license](LICENSE).
+
+[docs](https://docs.rs/todo-or-die)

--- a/src/github.rs
+++ b/src/github.rs
@@ -3,7 +3,7 @@ use anyhow::{Context as _, Result};
 use hyper::{
     header::HeaderValue,
     header::{ACCEPT, AUTHORIZATION},
-    Body, Request,
+    Request,
 };
 use serde::Deserialize;
 use syn::parse::Parse;
@@ -26,7 +26,7 @@ pub(crate) fn issue_closed(input: OrgRepoIssue) -> Result<Option<String>> {
                 "https://api.github.com/repos/{}/{}/issues/{}",
                 org, repo, issue_number
             ))
-            .body(Body::empty())
+            .body(())
             .unwrap(),
     )?)?;
 
@@ -58,7 +58,7 @@ pub(crate) fn pr_closed(input: OrgRepoIssue) -> Result<Option<String>> {
                 "https://api.github.com/repos/{}/{}/pulls/{}",
                 org, repo, issue_number
             ))
-            .body(Body::empty())
+            .body(())
             .unwrap(),
     )?)?;
 
@@ -72,7 +72,7 @@ pub(crate) fn pr_closed(input: OrgRepoIssue) -> Result<Option<String>> {
     }
 }
 
-fn github_request(mut request: Request<Body>) -> Result<Request<Body>> {
+fn github_request<B>(mut request: Request<B>) -> Result<Request<B>> {
     request.headers_mut().insert(
         ACCEPT,
         HeaderValue::from_static("application/vnd.github.v3+json"),

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,46 +1,71 @@
 use anyhow::{Context as _, Result};
+use chrono::prelude::*;
 use hyper::{
+    body::Bytes,
     client::{connect::dns::GaiResolver, HttpConnector},
     header::HeaderValue,
     header::USER_AGENT,
-    Body, Client, Request,
+    Body, Client, Request, Response,
 };
 use hyper_rustls::HttpsConnector;
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    hash::{Hash, Hasher},
+    path::PathBuf,
+};
 use tokio::runtime::Runtime;
 
-pub(crate) fn request<T>(mut request: Request<Body>) -> Result<T>
+pub(crate) fn request<T>(
+    // the request body isn't used in the cache key, so require it to be `()` so
+    // we can guarantee that its empty
+    request: Request<()>,
+) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
 {
     RUNTIME.block_on(async move {
+        let mut request = request.map(|_| Body::empty());
+
         request
             .headers_mut()
             .insert(USER_AGENT, HeaderValue::from_static("todo-or-die"));
 
-        let response = http_client()
-            .request(request)
-            .await
-            .context("HTTP request to failed")?;
+        let hash = hash_request(&request);
 
-        let status = response.status();
-        if !status.is_success() {
-            let body = hyper::body::to_bytes(response)
+        let response = if let Some(cached_response) =
+            cached_response(&hash).context("Failed to read cached response")?
+        {
+            cached_response
+        } else {
+            let response = http_client()
+                .request(request)
+                .await
+                .context("HTTP request to failed")?;
+
+            let (parts, body) = response.into_parts();
+            let body = hyper::body::to_bytes(body)
                 .await
                 .context("Failed to read response")?;
-            let body = String::from_utf8_lossy(&body);
+            let response = Response::from_parts(parts, body);
+
+            cache_response(hash, &response).context("Failed to cache response")?;
+
+            response
+        };
+
+        if !response.status().is_success() {
+            let body = String::from_utf8_lossy(response.body());
             anyhow::bail!(
                 "Received non-success response. status={}, body={:?}",
-                status,
+                response.status(),
                 body
             );
         }
 
-        let body = hyper::body::to_bytes(response)
-            .await
-            .context("Failed to read response")?;
-        let value = serde_json::from_slice::<T>(&body).context("Failed to parse response")?;
-
+        let value =
+            serde_json::from_slice::<T>(&*response.body()).context("Failed to parse response")?;
         Ok(value)
     })
 }
@@ -68,4 +93,112 @@ fn http_client() -> &'static HyperTlsClient {
     });
 
     &*CLIENT
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RequestHash(String);
+
+fn hash_request(request: &Request<Body>) -> RequestHash {
+    let mut hasher = DefaultHasher::new();
+    format!("{:?}", request).hash(&mut hasher);
+    let hash = hasher.finish();
+    RequestHash(hash.to_string())
+}
+
+fn cached_response(hash: &RequestHash) -> Result<Option<Response<Bytes>>> {
+    let path = cache_dir_path()?.join(&hash.0);
+
+    let data = match std::fs::read(&path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    if let Some(response) = deserialize_response(data)? {
+        Ok(Some(response))
+    } else {
+        std::fs::remove_file(&path)?;
+        Ok(None)
+    }
+}
+
+fn cache_response(hash: RequestHash, response: &Response<Bytes>) -> Result<()> {
+    let path = cache_dir_path()?.join(hash.0);
+    let bytes = serialize_response(response)?;
+    std::fs::write(path, bytes)?;
+    Ok(())
+}
+
+fn serialize_response(response: &Response<Bytes>) -> Result<Vec<u8>> {
+    let headers = response
+        .headers()
+        .iter()
+        .map(|(key, value)| (key.as_str().to_string(), value.as_bytes().to_vec()))
+        .collect();
+
+    let response = SerializedResponse {
+        status: response.status().as_u16(),
+        headers,
+        body: response.body().to_vec(),
+        expires_at: Local::now() + cache_ttl(),
+    };
+
+    Ok(serde_json::to_vec(&response)?)
+}
+
+fn cache_ttl() -> chrono::Duration {
+    (|| {
+        let var = std::env::var("TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS")?;
+        let sec = var.parse()?;
+        Ok::<_, anyhow::Error>(chrono::Duration::seconds(sec))
+    })()
+    .unwrap_or_else(|_| chrono::Duration::hours(1))
+}
+
+fn deserialize_response(data: Vec<u8>) -> Result<Option<Response<Bytes>>> {
+    let response = serde_json::from_slice::<SerializedResponse>(&data)
+        .context("Failed to deserialize cached HTTP response")?;
+
+    let expires_at = response.expires_at.timestamp();
+    let now = Local::now().timestamp();
+    if now > expires_at {
+        return Ok(None);
+    }
+
+    let status = hyper::StatusCode::from_u16(response.status)?;
+
+    let headers = response
+        .headers
+        .iter()
+        .map(|(key, value)| {
+            let key = hyper::header::HeaderName::from_bytes(key.as_bytes())?;
+            let value = HeaderValue::from_bytes(value)?;
+            Ok::<_, anyhow::Error>((key, value))
+        })
+        .collect::<Result<hyper::HeaderMap>>()
+        .context("Failed to build header map")?;
+
+    let body = Bytes::copy_from_slice(&response.body);
+
+    let mut out = Response::new(body);
+    *out.status_mut() = status;
+    *out.headers_mut() = headers;
+    Ok(Some(out))
+}
+
+#[derive(Serialize, Deserialize)]
+struct SerializedResponse {
+    status: u16,
+    headers: HashMap<String, Vec<u8>>,
+    body: Vec<u8>,
+    expires_at: DateTime<Local>,
+}
+
+fn cache_dir_path() -> Result<PathBuf> {
+    let todo_or_die_version = env!("CARGO_PKG_VERSION");
+    let path = std::env::temp_dir().join(format!("todo_or_die_{}_cache", todo_or_die_version));
+    std::fs::create_dir_all(&path).context("Failed to create dir to store HTTP caches")?;
+    Ok(path)
 }

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1,6 +1,6 @@
 use crate::http::request;
 use anyhow::{Context as _, Result};
-use hyper::{Body, Request};
+use hyper::Request;
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use syn::parse::Parse;
@@ -19,7 +19,7 @@ pub(crate) fn crates_io(input: Input) -> Result<Option<String>> {
     let data = request::<Response>(
         Request::builder()
             .uri(format!("https://crates.io/api/v1/crates/{}", input.krate))
-            .body(Body::empty())
+            .body(())
             .unwrap(),
     )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,11 @@
 //! immediately succeed. This can for example be used to skip checks locally and only perform them
 //! on CI.
 //!
+//! # Caching HTTP requests
+//!
+//! By default HTTP requests will be cached for 1 hour. You can change how long cached
+//! responses will be kept by setting `TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS`.
+//!
 //! # Feature flags
 //!
 //! The following optional features are available:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,17 +17,6 @@
 //! todo_or_die::crates_io!("serde", ">1.0.9000"); // its over 9000!
 //! ```
 //!
-//! # Skipping checks
-//!
-//! If the environment variable `TODO_OR_DIE_SKIP` is set all macros will do nothing and
-//! immediately succeed. This can for example be used to skip checks locally and only perform them
-//! on CI.
-//!
-//! # Caching HTTP requests
-//!
-//! By default HTTP requests will be cached for 1 hour. You can change how long cached
-//! responses will be kept by setting `TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS`.
-//!
 //! # Feature flags
 //!
 //! The following optional features are available:
@@ -38,6 +27,26 @@
 //! - `time`: Enables checking things to do with time.
 //!
 //! Note that _none_ of the features are enabled by default.
+//!
+//! # Skipping checks
+//!
+//! If the environment variable `TODO_OR_DIE_SKIP` is set all macros will do
+//! nothing and immediately succeed. This can for example be used to skip checks
+//! locally and only perform them on CI.
+//!
+//! # Caching HTTP requests
+//!
+//! By default HTTP requests will be cached for 1 hour. You can change how long
+//! cached responses will be kept by setting
+//! `TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS`.
+//!
+//! Caching can be disabled entirely by setting `TODO_OR_DIE_DISABLE_HTTP_CACHE`.
+//!
+//! # You can still compile offline
+//!
+//! If you're offline or GitHub is down you can still build. If the macros hit
+//! some kind of error a warning will be printed but they wont trigger a compile
+//! error.
 //!
 //! [ruby]: https://rubygems.org/gems/todo_or_die
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,14 @@
 //!
 //! # Caching HTTP requests
 //!
-//! By default HTTP requests will be cached for 1 hour. You can change how long
-//! cached responses will be kept by setting
-//! `TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS`.
+//! By default HTTP requests will be cached. The behavior can be customized with
+//! these environment variables:
+//! - `TODO_OR_DIE_HTTP_CACHE_TTL_SECONDS`: How long cached responses will be
+//! used. The default is 1 hour.
+//! - `TODO_OR_DIE_DISABLE_HTTP_CACHE`: Disables caching if its set.
+//! - `TODO_OR_DIE_CLEAR_HTTP_CACHE`: Clears the cache if its set.
 //!
-//! Caching can be disabled entirely by setting `TODO_OR_DIE_DISABLE_HTTP_CACHE`.
+//! The cache is stored at `std::env::temp_dir().join("todo_or_die_cache")`.
 //!
 //! # You can still compile offline
 //!


### PR DESCRIPTION
Caches HTTP requests for 1 hour by default. Can be customized via env var.

- [x] env var to clear the cache

Fixes https://github.com/davidpdrsn/todo-or-die/issues/2